### PR TITLE
[hotfix #1349] track trmjs: 因SPA網站不會觸發 onload event, 故增加 onhashevent

### DIFF
--- a/out/cap_trm.js
+++ b/out/cap_trm.js
@@ -58,17 +58,18 @@ TRM = (function() {
   };
 
   TRM.prototype.bindHashChangeEvent = function(info) {
-    var onhashchangeEvent;
+    var onhashchangeEvent, trmFlow;
     if (this.isInitHashChangeEvent) {
       return;
     }
     this.isInitHashChangeEvent = true;
     onhashchangeEvent = window.onhashchange;
+    trmFlow = this.setNGo;
     window.onhashchange = function() {
       if (onhashchangeEvent) {
         onhashchangeEvent();
       }
-      return this.setNGo(info);
+      return trmFlow(info);
     };
   };
 

--- a/out/cap_trm.js
+++ b/out/cap_trm.js
@@ -31,7 +31,8 @@ TRM = (function() {
       TARGET_DATA: TARGET_DATA
     };
     this.pmdReturnData = {};
-    this.isInitHashChangeEvent = false;
+    this.hasInitFacebookPixel = false;
+    this.hasInitHashChangeEvent = false;
     this.supportHashChangeTrmVersion = 24;
     this.KEYS = {
       ID: "pmd.uuid",
@@ -51,7 +52,7 @@ TRM = (function() {
     this.pmdReturnData = _lodash.cloneDeep(info);
     this.flow();
     isSupport = this.checkTrmVersion(this.supportHashChangeTrmVersion);
-    if (isSupport) {
+    if (isSupport || this.hasInitHashChangeEvent) {
       return;
     }
     return this.bindHashChangeEvent(info);
@@ -59,11 +60,8 @@ TRM = (function() {
 
   TRM.prototype.bindHashChangeEvent = function(info) {
     var onhashchangeEvent, that;
-    if (this.isInitHashChangeEvent) {
-      return;
-    }
     that = this;
-    this.isInitHashChangeEvent = true;
+    this.hasInitHashChangeEvent = true;
     onhashchangeEvent = window.onhashchange;
     window.onhashchange = function() {
       if (onhashchangeEvent) {
@@ -88,7 +86,9 @@ TRM = (function() {
   TRM.prototype.flow = function() {
     var that, triggers;
     that = this;
-    this.initFacebookPixel();
+    if (!this.hasInitFacebookPixel) {
+      this.initFacebookPixel();
+    }
     this.touchFacebookEvent(["track", "PageView"]);
     this.touchFacebookEvent(["track", "ViewContent"]);
     this.id = this.data.trackPixelId;
@@ -113,7 +113,8 @@ TRM = (function() {
     if (!this.hasFbPixelId()) {
       return;
     }
-    return this.touchFacebookEvent(["init", this.fbPixelId]);
+    this.touchFacebookEvent(["init", this.fbPixelId]);
+    return this.hasInitFacebookPixel = true;
   };
 
   TRM.prototype.touchFacebookEvent = function(dataArray) {

--- a/out/cap_trm.js
+++ b/out/cap_trm.js
@@ -58,18 +58,18 @@ TRM = (function() {
   };
 
   TRM.prototype.bindHashChangeEvent = function(info) {
-    var onhashchangeEvent, trmFlow;
+    var onhashchangeEvent, that;
     if (this.isInitHashChangeEvent) {
       return;
     }
+    that = this;
     this.isInitHashChangeEvent = true;
     onhashchangeEvent = window.onhashchange;
-    trmFlow = this.setNGo;
     window.onhashchange = function() {
       if (onhashchangeEvent) {
         onhashchangeEvent();
       }
-      return trmFlow(info);
+      return that.setNGo.call(that, info);
     };
   };
 

--- a/out/cap_trm.js
+++ b/out/cap_trm.js
@@ -21,8 +21,6 @@ _lodash = require("lodash");
 _lodash = _lodash.noConflict();
 
 TRM = (function() {
-  var checkTrmVersion;
-
   function TRM() {
     this.host = "{DOMAIN_NAME}/track";
     this.fbPixelId = "{FB_PIXEL_ID}";
@@ -74,7 +72,7 @@ TRM = (function() {
     };
   };
 
-  checkTrmVersion = function(supportTrmVersion) {
+  TRM.prototype.checkTrmVersion = function(supportTrmVersion) {
     var currentTrmVersion, isSupport;
     currentTrmVersion = window.analytics.VERSION || "0";
     isSupport = false;

--- a/out/cap_usage.js
+++ b/out/cap_usage.js
@@ -24,7 +24,7 @@
       return s.parentNode.insertBefore(t, s);
     },
     load: function(callback) {
-      var a, event, n;
+      var a, n, onhashchangeEvent, onloadEvent;
       if (!window.fbq) {
         this.initFbq();
       }
@@ -37,10 +37,19 @@
         n = document.getElementsByTagName("script")[0];
         n.parentNode.insertBefore(a, n);
       }
-      event = window.onload;
+      onloadEvent = window.onload;
       window.onload = function() {
-        if (event) {
-          event();
+        if (onloadEvent) {
+          onloadEvent();
+        }
+        if (callback && ({}.toString.call(callback) === '[object Function]')) {
+          return callback();
+        }
+      };
+      onhashchangeEvent = window.onhashchange;
+      window.onhashchange = function() {
+        if (onhashchangeEvent) {
+          onhashchangeEvent();
         }
         if (callback && ({}.toString.call(callback) === '[object Function]')) {
           return callback();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trm",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "tracking management client code",
   "main": "./out/cap_import.js",
   "scripts": {

--- a/src/cap_trm.coffee
+++ b/src/cap_trm.coffee
@@ -22,6 +22,7 @@ class TRM
     @targetTable = {TARGET_DATA}
     @pmdReturnData = {}
     @isInitHashChangeEvent = false
+    @supportHashChangeTrmVersion = 24  #trm v0.2.4
     @KEYS = {
       ID: "pmd.uuid"
       ADGROUP: "pmd.adGroupId"
@@ -41,6 +42,11 @@ class TRM
     @info = info
     @pmdReturnData = _lodash.cloneDeep info
     @flow()
+
+    isSupport = @checkTrmVersion(@supportHashChangeTrmVersion)
+
+    if isSupport
+      return
     @bindHashChangeEvent(info)
 
 
@@ -55,6 +61,18 @@ class TRM
       onhashchangeEvent() if onhashchangeEvent
       @setNGo(info)
     return
+
+  checkTrmVersion = (supportTrmVersion) ->
+    currentTrmVersion = window.analytics.VERSION or "0"
+    isSupport = false
+
+    if currentTrmVersion and supportTrmVersion
+      currentTrmVersion = currentTrmVersion.replace(/\./g, "")
+      currentTrmVersion = parseInt currentTrmVersion
+
+      isSupport = currentTrmVersion >= supportTrmVersion
+
+    return isSupport
 
   flow: () ->
 
@@ -321,7 +339,7 @@ class TRM
 
 global = window || module.exports
 global.analytics = global.analytics || []
-global.analytics = new TRM()
+global.analytics = _lodash.merge(global.analytics, new TRM())
 global.analytics.host = "{DOMAIN_NAME}/track"
 global.console = global.console || {
   log: (msg) ->

--- a/src/cap_trm.coffee
+++ b/src/cap_trm.coffee
@@ -62,7 +62,7 @@ class TRM
       @setNGo(info)
     return
 
-  checkTrmVersion = (supportTrmVersion) ->
+  checkTrmVersion: (supportTrmVersion) ->
     currentTrmVersion = window.analytics.VERSION or "0"
     isSupport = false
 

--- a/src/cap_trm.coffee
+++ b/src/cap_trm.coffee
@@ -57,9 +57,10 @@ class TRM
 
     @isInitHashChangeEvent = true
     onhashchangeEvent = window.onhashchange
+    trmFlow = @setNGo
     window.onhashchange = ->
       onhashchangeEvent() if onhashchangeEvent
-      @setNGo(info)
+      trmFlow(info)
     return
 
   checkTrmVersion: (supportTrmVersion) ->

--- a/src/cap_trm.coffee
+++ b/src/cap_trm.coffee
@@ -55,12 +55,12 @@ class TRM
     if @isInitHashChangeEvent
       return
 
+    that = @
     @isInitHashChangeEvent = true
     onhashchangeEvent = window.onhashchange
-    trmFlow = @setNGo
     window.onhashchange = ->
       onhashchangeEvent() if onhashchangeEvent
-      trmFlow(info)
+      that.setNGo.call(that, info)
     return
 
   checkTrmVersion: (supportTrmVersion) ->

--- a/src/cap_trm.coffee
+++ b/src/cap_trm.coffee
@@ -21,6 +21,7 @@ class TRM
     @data = {PIXEL_DATA}
     @targetTable = {TARGET_DATA}
     @pmdReturnData = {}
+    @isInitHashChangeEvent = false
     @KEYS = {
       ID: "pmd.uuid"
       ADGROUP: "pmd.adGroupId"
@@ -40,8 +41,20 @@ class TRM
     @info = info
     @pmdReturnData = _lodash.cloneDeep info
     @flow()
+    @bindHashChangeEvent(info)
 
 
+
+  bindHashChangeEvent: (info) ->
+    if @isInitHashChangeEvent
+      return
+
+    @isInitHashChangeEvent = true
+    onhashchangeEvent = window.onhashchange
+    window.onhashchange = ->
+      onhashchangeEvent() if onhashchangeEvent
+      @setNGo(info)
+    return
 
   flow: () ->
 

--- a/src/cap_trm.coffee
+++ b/src/cap_trm.coffee
@@ -21,7 +21,8 @@ class TRM
     @data = {PIXEL_DATA}
     @targetTable = {TARGET_DATA}
     @pmdReturnData = {}
-    @isInitHashChangeEvent = false
+    @hasInitFacebookPixel = false
+    @hasInitHashChangeEvent = false
     @supportHashChangeTrmVersion = 24  #trm v0.2.4
     @KEYS = {
       ID: "pmd.uuid"
@@ -44,19 +45,12 @@ class TRM
     @flow()
 
     isSupport = @checkTrmVersion(@supportHashChangeTrmVersion)
-
-    if isSupport
-      return
+    return if isSupport or @hasInitHashChangeEvent
     @bindHashChangeEvent(info)
 
-
-
   bindHashChangeEvent: (info) ->
-    if @isInitHashChangeEvent
-      return
-
     that = @
-    @isInitHashChangeEvent = true
+    @hasInitHashChangeEvent = true
     onhashchangeEvent = window.onhashchange
     window.onhashchange = ->
       onhashchangeEvent() if onhashchangeEvent
@@ -78,7 +72,9 @@ class TRM
   flow: () ->
 
     that = @
-    @initFacebookPixel()
+    unless @hasInitFacebookPixel
+      @initFacebookPixel()
+
     @touchFacebookEvent ["track", "PageView"]
     @touchFacebookEvent ["track", "ViewContent"]
     @id = @data.trackPixelId
@@ -102,6 +98,7 @@ class TRM
     return if not this.hasFbPixelId()
 
     @touchFacebookEvent ["init", this.fbPixelId]
+    @hasInitFacebookPixel = true
 
 
 

--- a/src/cap_usage.coffee
+++ b/src/cap_usage.coffee
@@ -34,9 +34,14 @@
         n = document.getElementsByTagName("script")[0]
         n.parentNode.insertBefore a, n
 
-      event = window.onload
+      onloadEvent = window.onload
       window.onload = ->
-        event()  if event
+        onloadEvent() if onloadEvent
+        callback() if callback and ({}.toString.call(callback) is '[object Function]')
+
+      onhashchangeEvent = window.onhashchange
+      window.onhashchange = ->
+        onhashchangeEvent() if onhashchangeEvent
         callback() if callback and ({}.toString.call(callback) is '[object Function]')
 
       return


### PR DESCRIPTION
## #1349   onload event not triggered with single page
### 任務目標
1. 添加 hashchange event
2. trm `version 0.2.3` (包含)前，使用相容性方式 設定 hashchange event，
   `version 0.2.4` 以後，客戶端第一次 copy js 時，即 init hashchange event。
### 已完成項目

(1), (2)
